### PR TITLE
商品一覧の次へ、前へボタンの実装

### DIFF
--- a/src/main/java/com/example/itemdatamanagement/controller/ItemController.java
+++ b/src/main/java/com/example/itemdatamanagement/controller/ItemController.java
@@ -1,7 +1,6 @@
 package com.example.itemdatamanagement.controller;
 
 import java.util.List;
-import java.util.Locale;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
@@ -13,7 +12,6 @@ import org.springframework.data.domain.Page;
 
 import com.example.itemdatamanagement.domain.Category;
 import com.example.itemdatamanagement.domain.Image;
-import com.example.itemdatamanagement.domain.Item;
 import com.example.itemdatamanagement.domain.ItemAndCategory;
 import com.example.itemdatamanagement.form.SearchItemForm;
 import com.example.itemdatamanagement.service.CategoryService;
@@ -42,6 +40,8 @@ public class ItemController {
 
     @RequestMapping("/findAll")
     public String findAll(SearchItemForm form, Model model, Integer page) {
+        model.addAttribute("form", form);
+
         List<ItemAndCategory> itemAndCategoryList = null;
 
         // ページング機能追加
@@ -49,6 +49,7 @@ public class ItemController {
             // ページ数の指定が無い場合は1ページ目を表示させる
             page = 1;
         }
+        model.addAttribute("page", page);
 
         String nameAll;
 
@@ -87,8 +88,10 @@ public class ItemController {
         } else {
             // 検索ボックスに入力があれば条件を指定して検索
             itemAndCategoryList = itemAndCategoryService.searchItem(form.getName(), nameAll, form.getBrand());
+
             // ページングの数字からも検索できるように検索条件をスコープに格納しておく
             model.addAttribute("form", form);
+
             // 該当する検索結果がなければ全件返す
             if (itemAndCategoryList == null) {
                 itemAndCategoryList = itemService.findAll();
@@ -101,8 +104,8 @@ public class ItemController {
         model.addAttribute("itemPage", itemPage);
 
         // ページングのリンクに使うページ数をスコープに格納 (例)28件あり1ページにつき10件表示させる場合→1,2,3がpageNumbersに入る
-        // List<Integer> pageNumbers = calcPageNumbers(model, itemPage);
-        // model.addAttribute("pageNumbers", pageNumbers);
+        int totalPages = itemPage.getTotalPages();
+        model.addAttribute("totalPages", totalPages);
 
         List<Category> parentCategoryList = categoryService.findAllParentCategory();
         model.addAttribute("parentCategoryList", parentCategoryList);

--- a/src/main/resources/templates/item/list.html
+++ b/src/main/resources/templates/item/list.html
@@ -54,14 +54,15 @@
         <div id="forms">
             <form th:action="@{/findAll}" class="form-inline" role="form" method="post">
                 <div class="form-group">
-                    <input type="input" class="form-control" id="name" placeholder="item name" name="name" />
+                    <input type="input" class="form-control" id="name" placeholder="item name" name="name"
+                        th:value="${form.name}" />
                 </div>
                 <div class="form-group"><i class="fa fa-plus"></i></div>
                 <div class="form-group">
                     <select class="form-control" name="parentCategory">
                         <option value="">- parentCategory -</option>
                         <option th:each="parentCategory : ${parentCategoryList}">
-                            <span th:text="${parentCategory.name}" th:value="${parentCategory.name}">
+                            <span th:text="${parentCategory.name}" th:value="${form.parentCategory}">
                                 parentCategory1
                             </span>
                         </option>
@@ -69,7 +70,7 @@
                     <select class="form-control" name="childCategory">
                         <option value="">- childCategory -</option>
                         <option th:each="childCategory : ${childCategoryList}">
-                            <span th:text="${childCategory.name}" th:value="${childCategory.name}">
+                            <span th:text="${childCategory.name}" th:value="${form.childCategory}">
                                 childCategory1
                             </span>
                         </option>
@@ -77,7 +78,7 @@
                     <select class="form-control" name="grandChild">
                         <option value="">- grandChild -</option>
                         <option th:each="grandChild : ${grandChildList}">
-                            <span th:text="${grandChild.name}" th:value="${grandChild.name}">
+                            <span th:text="${grandChild.name}" th:value="${form.grandChild}">
                                 grandChild1
                             </span>
                         </option>
@@ -85,7 +86,7 @@
                 </div>
                 <div class="form-group"><i class="fa fa-plus"></i></div>
                 <div class="form-group">
-                    <input type="text" class="form-control" placeholder="brand" name="brand" />
+                    <input type="text" class="form-control" placeholder="brand" name="brand" th:value="${form.brand}" />
                 </div>
                 <div class="form-group"></div>
                 <button type="submit" class="btn btn-default"><i class="fa fa-angle-double-right"></i> search</button>
@@ -96,8 +97,17 @@
         <div class="pages">
             <nav class="page-nav">
                 <ul class="pager">
-                    <li class="previous"><a href="#">&larr; prev</a></li>
-                    <li class="next"><a href="#">next &rarr;</a></li>
+                    <li class="previous">
+                        <span th:if="${page == 1}">&larr; prev</span>
+                        <a th:unless="${page == 1}" th:href="@{/findAll(page = ${page}-1,name = ${form.name})}">&larr;
+                            prev</a>
+                    </li>
+                    <li class="next">
+                        <span th:if="${page} == ${totalPages}">next &rarr;</span>
+                        <a th:unless="${page} == ${totalPages}"
+                            th:href="@{/findAll(page = ${page} + 1 , name = ${form.name})}">next
+                            &rarr;</a>
+                    </li>
                 </ul>
             </nav>
         </div>
@@ -158,8 +168,14 @@
         <div class="pages">
             <nav class="page-nav">
                 <ul class="pager">
-                    <li class="previous"><a href="#">&larr; prev</a></li>
-                    <li class="next"><a href="#">next &rarr;</a></li>
+                    <li class="previous">
+                        <span th:if="${page == 1}">&larr; prev</span>
+                        <a th:unless="${page == 1}" th:href="@{/findAll(page = ${page} - 1)}">&larr; prev</a>
+                    </li>
+                    <li class="next">
+                        <span th:if="${page == 20}">next &rarr;</span>
+                        <a th:unless="${page == 20}" th:href="@{/findAll(page = ${page} + 1)}">next &rarr;</a>
+                    </li>
                 </ul>
             </nav>
             <!-- ページ番号を指定して表示するフォーム -->


### PR DESCRIPTION
### バグ修正・新機能の説明
- 商品一覧の次へ、前へのボタンでページングできるようにしました。

### なぜ修正・追加するのか
- １ページごとのページ遷移ができなかったため。

### コードの重要な部分
- 

### 参考文献
- 
 
### 備考
- 
