### PR TITLE
商品一覧のカテゴリにリンクをつける

### DIFF
--- a/src/main/resources/templates/error/404.html
+++ b/src/main/resources/templates/error/404.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- css -->
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
+        integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"
+        integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous" />
+    <link rel="stylesheet" href="./style.css" />
+    <!-- script -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+        integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+        crossorigin="anonymous"></script>
+    <title>Rakus Items</title>
+</head>
+
+<body>
+    <h1>Error...</h1>
+    <h4>エラーが発生したため処理を中断しました。</h4>
+    <p>下のリンクから再度ログインをお願いします。</p>
+    <a th:href="@{/login}">【ログイン画面に戻る】</a>
+</body>
+
+</html>

--- a/src/main/resources/templates/error/5xx.html
+++ b/src/main/resources/templates/error/5xx.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- css -->
+    <link href="https://maxcdn.bootstrapcdn.com/font-awesome/4.7.0/css/font-awesome.min.css" rel="stylesheet"
+        integrity="sha384-wvfXpqpZZVQGK6TAh5PVlGOfQNHSoD2xbE+QkPxCAFlNEevoEH3Sl0sibVcOQVnN" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+        integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap-theme.min.css"
+        integrity="sha384-rHyoN1iRsVXV4nD0JutlnGaslCJuC7uwjduW9SVrLvRYooPp2bWYgmgJQIXwl/Sp" crossorigin="anonymous" />
+    <link rel="stylesheet" href="./style.css" />
+    <!-- script -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.12.4/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js"
+        integrity="sha384-Tc5IQib027qvyjSMfHjOMaLkfuWVxZxUPnCJA7l2mCWNIpG9mGCD8wGNIcPD7Txa"
+        crossorigin="anonymous"></script>
+    <title>Rakus Items</title>
+</head>
+
+<body>
+    <h1>Under maintenance...</h1>
+    <h4>ただいまメンテナンス中です。</h4>
+    <p>メンテナンス作業のためサービスを一時停止しております。</p>
+    <p>終了までしばらくお待ちください。</p>
+</body>
+
+</html>

--- a/src/main/resources/templates/item/list.html
+++ b/src/main/resources/templates/item/list.html
@@ -145,26 +145,30 @@
                             </td>
                             <td class="item-price" th:text="${'$'+item.price}">52.0</td>
                             <td class="item-category">
-                                <span th:text="${item.nameAll}"></span>
+                                <!-- <span th:each="category : ${#strings.split(item.nameAll, '/')}">
+                                    <a href="" th:text="${category}"></a>/
+                                </span> -->
+                                <a href="">
+                                    <span th:text="${#strings.substringBefore(item.nameAll,'/')}"></span>
+                                </a>/
+                                <a href="">
+                                    <span
+                                        th:text="${#strings.substringBefore(#strings.substringAfter(item.nameAll,'/'),'/')}"></span>
+                                </a>/
+                                <a href="">
+                                    <span th:text="${item.categoryName}"></span>
+                                </a>
                             </td>
                             <td class="item-brand"><a href="">
                                     <span th:text="${item.brand}">
                                         Razer
                                     </span></a></td>
                             <td class="item-condition" th:text="${item.condition}">3</td>
-                            <!-- <td>
-                                <button class="btn btn-danger">
-                                    <span class="glyphicon glyphicon-trash"></span>
-                                </button>
-                            </td> -->
                         </form>
                     </tr>
                 </tbody>
             </table>
         </div>
-        <!-- <div class="form-group"></div>
-            <button type="submit" class="btn btn-default"><i class="fa fa-angle-double-right"></i> delete</button>
-        </form> -->
 
         <!-- pagination -->
         <div class="pages">


### PR DESCRIPTION
### バグ修正・新機能の説明
- 商品一覧のカテゴリをリンク表示にしました。

### なぜ修正・追加するのか
- カテゴリを選択するとカテゴリに紐づく商品一覧が閲覧できるようにしたいため。

### コードの重要な部分
- /区切りで真ん中の値を表示させたい時は、以下のコードで表示できる。
- th:text="${#strings.substringBefore(#strings.substringAfter(item.nameAll,'/'),'/')}"

### 参考文献
-
 
### 備考
- 
